### PR TITLE
Linking to Encoders page as requested

### DIFF
--- a/programming/index.md
+++ b/programming/index.md
@@ -15,6 +15,7 @@ We also use [RobotPy](https://robotpy.readthedocs.io/en/stable/). Here are some 
 
 - [Anatomy of a Robot](https://robotpy.readthedocs.io/en/stable/guide/anatomy.html)
 - [MagicBot Framework](https://robotpy.readthedocs.io/en/stable/frameworks/magicbot.html)
+- [What Encoders are](Encoders)
 
 ## Git
 Our code is versioned using [Git](https://git-scm.com/). Git lets us collaborate on code and keep track of changes.

--- a/programming/index.md
+++ b/programming/index.md
@@ -15,7 +15,7 @@ We also use [RobotPy](https://robotpy.readthedocs.io/en/stable/). Here are some 
 
 - [Anatomy of a Robot](https://robotpy.readthedocs.io/en/stable/guide/anatomy.html)
 - [MagicBot Framework](https://robotpy.readthedocs.io/en/stable/frameworks/magicbot.html)
-- [What Encoders are](Encoders)
+- [Encoders](Encoders.d)
 
 ## Git
 Our code is versioned using [Git](https://git-scm.com/). Git lets us collaborate on code and keep track of changes.


### PR DESCRIPTION
Adding link to Encoders wiki page as I was asked to do.
Not one hundred percent if I linked it correctly, if I made a mistake please let me know what my error was, I'm still getting used to Markdown.